### PR TITLE
bump coq version to 8.18.0

### DIFF
--- a/incl/macros.html
+++ b/incl/macros.html
@@ -1,3 +1,3 @@
-<#def CURRENTVERSION>8.17.1</#def>
+<#def CURRENTVERSION>8.18.0</#def>
 <#def CURRENTVERSIONTAG>V<#CURRENTVERSION></#def>
 <#def CURRENTCREDITSURL>https://github.com/coq/coq/blob/<#CURRENTVERSIONTAG>/CREDITS</#def>


### PR DESCRIPTION
CC @Zimmi48:
- switch the default version of the reference manual on the website.
- publish a new manual version on Zenodo.