### PR TITLE
Update description of VSCode extensions

### DIFF
--- a/pages/user-interfaces.html
+++ b/pages/user-interfaces.html
@@ -18,7 +18,7 @@ install either
 the <a href="https://github.com/coq-community/vscoq">VsCoq
 extension</a>, or
 the <a href="https://github.com/ejgallego/coq-lsp">coq-lsp extension</a>.
-Both extensions are based on the <a
+Both extensions are now based on the <a
 href="https://microsoft.github.io/language-server-protocol">Language
 Server Protocol</a> standard, with custom extensions.
 </li>

--- a/pages/user-interfaces.html
+++ b/pages/user-interfaces.html
@@ -13,21 +13,14 @@ list such support extensions that are actively used and maintained:
 <ul>
 
 <li>
-<strong>Visual Studio Code</strong> and <strong>VSCodium</strong> users can use either of
+<strong>Visual Studio Code</strong> and <strong>VSCodium</strong> users can
+install either
 the <a href="https://github.com/coq-community/vscoq">VsCoq
-extension</a>, which is actively maintained by several contributors as part
-of <a href="https://github.com/coq-community/manifesto">coq-community</a>, or
-the new <a href="https://github.com/ejgallego/coq-lsp">coq-lsp extension</a>,
-which is based on an implementation of the <a
+extension</a>, or
+the <a href="https://github.com/ejgallego/coq-lsp">coq-lsp extension</a>.
+Both extensions are based on the <a
 href="https://microsoft.github.io/language-server-protocol">Language
 Server Protocol</a> standard, with custom extensions.
-
-<tt>coq-lsp</tt> provides continous document checking and position-based
-document navigation (an interaction model similar to what is found in e.g.,
-Lean, and which departs from the model found in other Coq user interfaces).
-See <tt>coq-lsp's</tt> <a
-href="https://github.com/ejgallego/coq-lsp/blob/main/etc/FAQ.md">FAQ</a>
-for more information.
 </li>
 
 <li>


### PR DESCRIPTION
The info was outdated. This is a minimal fix.