### PR TITLE
Most needed changes to Coq's UI page.

### DIFF
--- a/pages/user-interfaces.html
+++ b/pages/user-interfaces.html
@@ -60,14 +60,7 @@ or for <a href="https://github.com/tomtomjhj/coq-lsp.nvim">coq-lsp</a>.
 <p>
 Alternatively, you can
 use <a href="https://coq.inria.fr/refman/practical-tools/coqide.html">CoqIDE</a>,
-which is developed and distributed alongside Coq. CoqIDE relies
-on <a href="https://github.com/coq/coq/blob/master/dev/doc/xml-protocol.md">Coq's
-XML protocol for IDEs</a> and implements all of the features provided
-by this protocol, meaning in particular asynchronous evaluation.
-CoqIDE comes with standard basic Emacs-like bindings
-and with some specific Coq-related bindings but, as an editor, it is
-not as complete as a general-purpose editor could be (for instance it
-does not have automatic indentation).
+a standalone desktop application which is developed and distributed alongside Coq.
 </p>
 
 <p>

--- a/pages/user-interfaces.html
+++ b/pages/user-interfaces.html
@@ -66,10 +66,7 @@ a standalone desktop application which is developed and distributed alongside Co
 <p>
 As a way to try Coq without installing anything, you can
 use <a href="https://jscoq.github.io/">JsCoq</a>.  JsCoq loads Coq
-entirely in your browser.  However, it is too limited to conduct
-actual projects: it lacks access to the VM and native computing
-machineries of Coq, and may hit out-of-memory and stack-overflow
-failures quicker than native versions of Coq.
+entirely in your browser.
 </p>
 
 </div>

--- a/pages/user-interfaces.html
+++ b/pages/user-interfaces.html
@@ -36,11 +36,10 @@ hand, async proof processing is not supported.
 </li>
 
 <li>
-<strong>Vim/NeoVim</strong> users can use the actively
-maintained <a href="https://github.com/whonore/Coqtail">Coqtail</a>
-extension.  This extension is partly based upon a previous, and now
-unmaintained, Vim extension
-called <a href="https://github.com/the-lambda-church/coquille">Coquille</a>.
+<strong>Vim/NeoVim</strong> users can use the <a href="https://github.com/whonore/Coqtail">Coqtail</a>
+extension.  NeoVim users can also test the experimental support for
+<a href="https://github.com/tomtomjhj/vscoq.nvim">VsCoq's vscoqtop server</a>
+or for <a href="https://github.com/tomtomjhj/coq-lsp.nvim">coq-lsp</a>.
 </li>
 
 </ul>

--- a/pages/user-interfaces.html
+++ b/pages/user-interfaces.html
@@ -41,17 +41,6 @@ or for <a href="https://github.com/tomtomjhj/coq-lsp.nvim">coq-lsp</a>.
 
 </p>
 
-<p>
-An experimental alternative to the editors mentioned above is the
-computational notebook interface provided by Jupyter.
-A <a href="https://github.com/EugeneLoy/coq_jupyter/">Jupyter kernel
-for Coq</a> is available if you want to try this interface, for
-instance for pedagogical or readability purposes.  One of the
-advantages of using a Jupyter notebook is that you can save and
-display a selection of intermediate proof steps, which your reader
-will see without the need to reexecute the document.
-</p>
-
 </div>
 
 <div class="frameworklinks">
@@ -110,6 +99,11 @@ additional user interfaces that have stayed at the experimental level
 or whose maintenance has been discontinued and or is currently
 uncertain:
 <ul>
+<li>
+A <a href="https://github.com/EugeneLoy/coq_jupyter/">Jupyter kernel for Coq</a>
+(supports Coq 8.6 and newer versions using <a href="https://github.com/coq/coq/blob/master/dev/doc/xml-protocol.md">Coq's
+XML protocol for IDEs</a>).
+</li>
 <li>
 The <a href="http://coqoon.github.io/">Coqoon</a> Eclipse plugin was
 initially based upon

--- a/pages/user-interfaces.html
+++ b/pages/user-interfaces.html
@@ -28,11 +28,6 @@ Server Protocol</a> standard, with custom extensions.
 mode <a href="https://proofgeneral.github.io/">Proof General</a>, that
 can be extended by the minor Coq
 mode <a href="https://github.com/cpitclaudel/company-coq">Company-Coq</a>.
-Proof General was one of the first user interface for proof
-assistants, and is one of the most used user interface for Coq today.
-Proof General and Company-Coq give access to many productivity
-shortcuts, including auto-completion and documentation.  On the other
-hand, async proof processing is not supported.
 </li>
 
 <li>


### PR DESCRIPTION
@herbelin As an alternative to #218, here are a few commits which implement the most needed changes to Coq's UI page without making any radical change (in particular to the structure).

Mostly, we:

- remove excessive information that cluttered the page
- move coq_jupyter to the top of the experimental section (since it doesn't really fit the "actively used" category)
- mention the existence of experimental NeoVim support for VsCoq and coq-lsp (although we might want to remove this mention if this experimental support stops being actively maintained in the future; for now, both linked projects are actively maintained by the same person).

I'm happy to drop any commit to make the merging of this PR quick and without debate. (Each commit can be considered independent.) I have no will to spend any time debating any of this change.

Here is what the page looks with these changes applied:

![image](https://github.com/coq/coq.github.io/assets/1108325/d39a249e-b68f-4853-a708-3b78325879e1)

For reference, here is how it currently looks:

![image](https://github.com/coq/coq.github.io/assets/1108325/03783248-7697-4051-8dae-2f831e5abe7f)
