### PR TITLE
propagate hash fragment (=href anchor) when redirecting URLs 

### DIFF
--- a/pages/404.html
+++ b/pages/404.html
@@ -1,6 +1,7 @@
 <#include "incl/macros.html">
 <script>
   const path = window.location.pathname;
+  const hash = window.location.hash;
   const stdlibRegex = /^\/(stdlib|library)\//;
   const refmanRegex = /^\/distrib\/(.*)\/refman\//;
   const V80refmanRegex = /^\/distrib\/V8.0\/doc\//;
@@ -10,25 +11,25 @@
   const bugSearchRegex = /^\?id=(.*)/;
   const wikiRegex = /^\/cocorico\/(.*)/;
   if (stdlibRegex.test(path)) {
-    window.location = path.replace(stdlibRegex, "/doc/<#CURRENTVERSIONTAG>/stdlib/");
+    window.location = path.replace(stdlibRegex, "/doc/<#CURRENTVERSIONTAG>/stdlib/") + hash;
   } else if (refmanRegex.test(path)) {
     const version = path.match(refmanRegex)[1];
     if (version == "current") {
-      window.location = path.replace(refmanRegex, "/doc/<#CURRENTVERSIONTAG>/refman/");
+      window.location = path.replace(refmanRegex, "/doc/<#CURRENTVERSIONTAG>/refman/") + hash;
     }
     else {
-      window.location = path.replace(refmanRegex, "/doc/" + version + "/refman/");
+      window.location = path.replace(refmanRegex, "/doc/" + version + "/refman/") + hash;
     }
   } else if (stdlibDistribRegex.test(path)) {
     const version = path.match(stdlibDistribRegex)[1];
     if (version == "current") {
-      window.location = path.replace(stdlibDistribRegex, "/doc/<#CURRENTVERSIONTAG>/stdlib/");
+      window.location = path.replace(stdlibDistribRegex, "/doc/<#CURRENTVERSIONTAG>/stdlib/") + hash;
     }
     else {
-      window.location = path.replace(stdlibDistribRegex, "/doc/" + version + "/stdlib/");
+      window.location = path.replace(stdlibDistribRegex, "/doc/" + version + "/stdlib/") + hash;
     }
   } else if (V80refmanRegex.test(path)) {
-    window.location = path.replace(V80refmanRegex, "/doc/V8.0/doc/");
+    window.location = path.replace(V80refmanRegex, "/doc/V8.0/doc/") + hash;
   } else if (bugSimplifiedRegex.test(path)) {
     const bugId = path.match(bugSimplifiedRegex)[1];
     // To avoid having to rely on the correspondence table from the migration, we redirect to the search page

--- a/srv/server.py
+++ b/srv/server.py
@@ -1,10 +1,24 @@
-import http.server
-from http.server import HTTPServer, BaseHTTPRequestHandler
+from http.server import SimpleHTTPRequestHandler
 import socketserver
 
 PORT = 8000
 
-Handler = http.server.SimpleHTTPRequestHandler
+
+class Handler(SimpleHTTPRequestHandler):
+    def send_error(self, code, message=None):
+        if code == 404:
+            with open("404.html", "rb") as err_msg:
+                page404 = err_msg.read()
+
+            self.send_response(code)
+            self.send_header("Connection", "close")
+            self.send_header("Content-Type", "text/html")
+            self.send_header("Content-Length", str(len(page404)))
+            self.end_headers()
+            self.wfile.write(page404)
+        else:
+            SimpleHTTPRequestHandler.send_error(self, code, message)
+
 
 Handler.extensions_map={
     '.manifest': 'text/cache-manifest',


### PR DESCRIPTION
When redirecting requests for stdlib or refman pages, propagate the
URL's fragment identifer (the string following the '#' sign, if any).

This is required for stdlib URLs so that links generated by coqdoc
resolve to specifc identifiers, as intended.

While at it, also preserve the fragment identifier in refman pages, in
case someone, somewhere meant to link to specific parts of the
reference manual.

Fixes: https://github.com/coq/coq.github.io/issues/235

Aside: tweaked `srv/server.py` to be able to test the 404 page locally.