### PR TITLE
mention the Rocq rename

### DIFF
--- a/incl/footer.html
+++ b/incl/footer.html
@@ -14,7 +14,8 @@ Still opened: html body div.container div#content div.node div.content
       <div style="background-color: blanchedalmond; padding-left: 5px;" class="content">
         <p>October 2023: we have decided to rename 'Coq' into 'The Rocq Prover'.
           Renaming all existing resources is a lot of work, it will be a slow, gradual transition.
-          During this transition period, please feel free to mention the proof assistant as Coq/Rocq.
+          During this transition period, please feel free to use both names, for example
+          by writing "formalized with Rocq (formerly Coq)" or "formalized with Coq (also named Rocq)".
         </p>
       </div>
       <div style="padding-left: 5px;" class="content">

--- a/incl/footer.html
+++ b/incl/footer.html
@@ -12,7 +12,7 @@ Still opened: html body div.container div#content div.node div.content
     <div id="block-aggregator-feed-1" class="clear-block block block-aggregator">
       <h2 class="title">Recent news</h2>
       <div style="background-color: blanchedalmond; padding-left: 5px;" class="content">
-        <p>October 2023: we have decided to rename 'Coq' into 'The Rocq Prover'. The rename is currently in preparation, and will hopefully happen sometime in 2024.</p>
+        <p>The Coq team has decided that Coq will be renamed into 'The Rocq Prover'. Background information available <a href="https://coq.discourse.group/t/coq-community-survey-2022-results-part-iv-and-itp-paper-announcement/2001#renaming-coq-8">here</a>. The rename is currently in preparation, we hope to have a new visual identity and website by the end of 2024, and to do a first release of Rocq around that time.</p>
       </div>
       <div style="padding-left: 5px;" class="content">
         <p>There is now a Stack Exchange Q&amp;A site dedicated to <a href="https://proofassistants.stackexchange.com">Proof Assistants</a>! Do not hesitate to post and answer Coq questions there (use the <a href="https://proofassistants.stackexchange.com/questions/tagged/coq">coq</a> tag).</p>

--- a/incl/footer.html
+++ b/incl/footer.html
@@ -12,6 +12,12 @@ Still opened: html body div.container div#content div.node div.content
     <div id="block-aggregator-feed-1" class="clear-block block block-aggregator">
       <h2 class="title">Recent news</h2>
       <div style="background-color: blanchedalmond; padding-left: 5px;" class="content">
+        <p>October 2023: we have decided to rename 'Coq' into 'The Rocq Prover'.
+          Renaming all existing resources is a lot of work, it will be a slow, gradual transition.
+          During this transition period, please feel free to mention the proof assistant as Coq/Rocq.
+        </p>
+      </div>
+      <div style="padding-left: 5px;" class="content">
         <p>There is now a Stack Exchange Q&amp;A site dedicated to <a href="https://proofassistants.stackexchange.com">Proof Assistants</a>! Do not hesitate to post and answer Coq questions there (use the <a href="https://proofassistants.stackexchange.com/questions/tagged/coq">coq</a> tag).</p>
       </div>
       <div style="padding-left: 5px;" class="content">

--- a/incl/footer.html
+++ b/incl/footer.html
@@ -12,11 +12,7 @@ Still opened: html body div.container div#content div.node div.content
     <div id="block-aggregator-feed-1" class="clear-block block block-aggregator">
       <h2 class="title">Recent news</h2>
       <div style="background-color: blanchedalmond; padding-left: 5px;" class="content">
-        <p>October 2023: we have decided to rename 'Coq' into 'The Rocq Prover'.
-          Renaming all existing resources is a lot of work, it will be a slow, gradual transition.
-          During this transition period, please feel free to use both names, for example
-          by writing "formalized with Rocq (formerly Coq)" or "formalized with Coq (also named Rocq)".
-        </p>
+        <p>October 2023: we have decided to rename 'Coq' into 'The Rocq Prover'. The rename is currently in preparation, and will hopefully happen sometime in 2024.</p>
       </div>
       <div style="padding-left: 5px;" class="content">
         <p>There is now a Stack Exchange Q&amp;A site dedicated to <a href="https://proofassistants.stackexchange.com">Proof Assistants</a>! Do not hesitate to post and answer Coq questions there (use the <a href="https://proofassistants.stackexchange.com/questions/tagged/coq">coq</a> tag).</p>

--- a/incl/header.html
+++ b/incl/header.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 
 <head>
-  <title><#TITLE> | The Coq/Rocq Proof Assistant</title>
+  <title><#TITLE> | The Coq Proof Assistant, the Rocq prover</title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <link rel="shortcut icon" href="/files/coq_favicon.ico" type="image/x-icon" />
   <link type="text/css" rel="stylesheet" media="all" href="/styles/barron/style.css" />
@@ -30,7 +30,7 @@
         <div id="logo">
           <a href="/" title="Home"><img src="/files/barron_logo.png" alt="Home" /></a>
         </div>
-        <h1 class="site-name"><a href="/" title="Home">The Coq/Rocq Proof Assistant</a></h1>
+        <h1 class="site-name"><a href="/" title="Home">The Coq (Rocq) Proof Assistant</a></h1>
       </div><!-- /logo-wrapper-->
     </div><!-- /header-->
 

--- a/incl/header.html
+++ b/incl/header.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 
 <head>
-  <title><#TITLE> | The Coq Proof Assistant, the Rocq prover</title>
+  <title><#TITLE> | The Coq Proof Assistant</title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <link rel="shortcut icon" href="/files/coq_favicon.ico" type="image/x-icon" />
   <link type="text/css" rel="stylesheet" media="all" href="/styles/barron/style.css" />
@@ -30,7 +30,7 @@
         <div id="logo">
           <a href="/" title="Home"><img src="/files/barron_logo.png" alt="Home" /></a>
         </div>
-        <h1 class="site-name"><a href="/" title="Home">The Coq (Rocq) Proof Assistant</a></h1>
+        <h1 class="site-name"><a href="/" title="Home">The Coq Proof Assistant</a></h1>
       </div><!-- /logo-wrapper-->
     </div><!-- /header-->
 

--- a/incl/header.html
+++ b/incl/header.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 
 <head>
-  <title><#TITLE> | The Coq Proof Assistant</title>
+  <title><#TITLE> | The Coq/Rocq Proof Assistant</title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <link rel="shortcut icon" href="/files/coq_favicon.ico" type="image/x-icon" />
   <link type="text/css" rel="stylesheet" media="all" href="/styles/barron/style.css" />
@@ -30,7 +30,7 @@
         <div id="logo">
           <a href="/" title="Home"><img src="/files/barron_logo.png" alt="Home" /></a>
         </div>
-        <h1 class="site-name"><a href="/" title="Home">The Coq Proof Assistant</a></h1>
+        <h1 class="site-name"><a href="/" title="Home">The Coq/Rocq Proof Assistant</a></h1>
       </div><!-- /logo-wrapper-->
     </div><!-- /header-->
 


### PR DESCRIPTION
The Coq team announced a rename months ago, but there is no sign of it on the webpage. This is silly!

The present PR adds just a couple mentions of the new Rocq name, enough for people to know that this is happening for real -- but not enough that it is a lot of work or that tricky questions have to be answered for consistency.

The proposed explanation includes an invitation to use the combined name "Coq/Rocq" during a transition period, so that people that only know of the old name (that is, almost everyone) does not get lost. This is used on the webpage itself, whose title is now "The Coq/Rocq proof assistant."
